### PR TITLE
Use git describe to version Docker images produced by buildkit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,22 @@
 buildscript {
     repositories {
         gradlePluginPortal()
+        maven {
+            url = uri("https://plugins.gradle.org/m2/")
+        }
     }
     dependencies {
         classpath("ca.islandora:isle-gradle-docker-plugin:0.0.1")
+        classpath("com.palantir.gradle.gitversion:gradle-git-version:0.12.3")
     }
 }
+
+allprojects {
+    apply(plugin = "com.palantir.git-version")
+    val gitVersion: groovy.lang.Closure<String> by extra
+    if (version == "unspecified" || version.toString().trim() == "") {
+      version = gitVersion()
+    }
+}
+
 apply(plugin = "ca.islandora.gradle.docker")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.parallel=true
-# Will be used as a tag to denote the images release.
+# Will be used as a tag to denote the images release.  If this property is empty or undefined, the version will be
+# obtained by the output of git-describe.
 version=0.0.1
 # The project can be build with/without Buildkit for those on older versions of Docker earlier than '18.09' or who
 # cannot use the 'overlay2' filesystem with Docker due to using an earlier kernel version than 4.0.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.parallel=true
 # Will be used as a tag to denote the images release.  If this property is empty or undefined, the version will be
 # obtained by the output of git-describe.
-version=0.0.1
+version=
 # The project can be build with/without Buildkit for those on older versions of Docker earlier than '18.09' or who
 # cannot use the 'overlay2' filesystem with Docker due to using an earlier kernel version than 4.0.
 useBuildKit=true


### PR DESCRIPTION
See description on the [upstream PR](https://github.com/Islandora-Devops/isle-buildkit/pull/83).

This PR updates the `version=` property to be the empty string, which will result in Docker image tags based on `git describe`.